### PR TITLE
Update embedded_hal to 0.2, add CRC, and borrow the delay object

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.1.1"
 
 [dependencies]
 byteorder = { version = "1", default-features = false }
-embedded-hal = "0.1.1"
+embedded-hal = "0.2.4"
 
 [dev-dependencies]
-linux-embedded-hal = "0.1.1"
+linux-embedded-hal = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.1.1"
 
 [dependencies]
 byteorder = { version = "1", default-features = false }
-embedded-hal = "0.1.1"
+embedded-hal = "0.2.1"
 
 [dev-dependencies]
-linux-embedded-hal = "0.1.1"
+linux-embedded-hal = "0.2.1"

--- a/examples/raspberrypi.rs
+++ b/examples/raspberrypi.rs
@@ -8,11 +8,11 @@ fn main() {
     println!("Hello, SHT31!");
 
     let dev = I2cdev::new("/dev/i2c-1").unwrap();
-    let mut sht31 = SHT3x::new(dev, Delay, Address::Low);
+    let mut sht31 = SHT3x::new(dev, Address::Low);
 
     println!("Status raw: {:?}", sht31.status().unwrap());
     loop {
-        let m = sht31.measure(Repeatability::High).unwrap();
+        let m = sht31.measure(Repeatability::High, &mut Delay).unwrap();
         println!("Temp: {:.2} Humidity: {:.2}", m.temperature, m.humidity);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,20 +10,18 @@ use byteorder::{ByteOrder, BigEndian};
 use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::blocking::i2c::{Read, Write, WriteRead};
 
-pub struct SHT3x<I2C, D> {
+pub struct SHT3x<I2C> {
     i2c: I2C,
-    delay: D,
     address: Address,
 }
 
-impl<I2C, D, E> SHT3x<I2C, D>
+impl<I2C, E> SHT3x<I2C>
 where
     I2C: Read<Error = E> + Write<Error = E> + WriteRead<Error = E>,
-    D: DelayMs<u8>,
 {
 	/// Creates a new driver
-    pub fn new(i2c: I2C, delay: D, address: Address) -> Self {
-        SHT3x { i2c, delay, address }
+    pub fn new(i2c: I2C, address: Address) -> Self {
+        SHT3x { i2c, address }
     }
 
 	/// Send an I2C command
@@ -36,9 +34,9 @@ where
     }
 
 	/// Take a temperature and humidity measurement
-    pub fn measure(&mut self, rpt: Repeatability) -> Result<Measurement, Error<E>> {
+    pub fn measure<D: DelayMs<u8>>(&mut self, rpt: Repeatability, delay: &mut D) -> Result<Measurement, Error<E>> {
         self.command(Command::SingleShot(ClockStretch::Disabled, rpt))?;
-        self.delay.delay_ms(rpt.max_duration());
+        delay.delay_ms(rpt.max_duration());
         let mut buf = [0; 6];
         self.i2c.read(self.address as u8, &mut buf)
                 .map_err(Error::I2c)?;
@@ -112,6 +110,7 @@ pub enum Address {
     Low = 0x44,
 }
 
+#[allow(unused)]
 enum Command {
     SingleShot(ClockStretch, Repeatability),
     Periodic(Rate, Repeatability),
@@ -125,13 +124,14 @@ enum Command {
     ClearStatus,
 }
 
+#[allow(unused)]
 enum ClockStretch {
     Enabled,
     Disabled,
 }
 
 /// Periodic data acquisition rate
-#[allow(non_camel_case_types)]
+#[allow(non_camel_case_types, unused)]
 enum Rate {
 	/// 0.5 measurements per second
     R0_5,


### PR DESCRIPTION
I've taken @iicurtis' fork that updates embedded_hal and adds the CRC check and updated it so that we borrow the DelayMs object instead of taking ownership. This is to allow e.g. multiple sensors to use the delay timer by borrowing it when it's needed.

With these updates, usage of this crate now looks like this (on an STM32F103 platform):
```rust
let cp = cortex_m::Peripherals::take().unwrap();
let mut delay = Delay::new(cp.SYST, clocks);
let i2c = stm32f1xx_hal::i2c::BlockingI2c::i2c1( ... );
let mut sht35 = SHT3x::new(i2c, Address::Low);
let measurements = sht35.measure(Repeatability::High, &mut delay).unwrap();
```